### PR TITLE
Server side support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,7 @@ import tap from 'redux-tap'
 
 const filterError = ({ meta }) => meta && meta.error
 
-const warn = () => window !== 'undefined' &&
-  typeof window.Bugsnag !== 'object' &&
+const warn = () => console &&
   console.warn('redux-bugsnag has been executed but it seems like Bugsnag snippet has not been loaded.')
 
 export default (bugsnag) => tap(filterError, (error, action, store) => {

--- a/src/index.js
+++ b/src/index.js
@@ -6,8 +6,12 @@ const warn = () => window !== 'undefined' &&
   typeof window.Bugsnag !== 'object' &&
   console.warn('redux-bugsnag has been executed but it seems like Bugsnag snippet has not been loaded.')
 
-export default () => tap(filterError, (error, action, store) => {
-  typeof window !== 'undefined' && typeof window.Bugsnag === 'object'
-    ? window.Bugsnag.notifyException(error)
-    : warn()
+export default (bugsnag) => tap(filterError, (error, action, store) => {
+  if (!bugsnag && typeof window !== 'undefined' && typeof window.Bugsnag === 'object') {
+    bugsnag = window.Bugsnag
+  } else if (bugsnag) {
+    typeof bugsnag.notifyException === 'function' ? bugsnag.notifyException(error) : bugsnag.notify(error)
+  } else {
+    return warn()
+  }
 })

--- a/src/index.js
+++ b/src/index.js
@@ -6,9 +6,7 @@ const warn = () => console &&
   console.warn('redux-bugsnag has been executed but it seems like Bugsnag snippet has not been loaded.')
 
 export default (bugsnag) => tap(filterError, (error, action, store) => {
-  if (!bugsnag && typeof window !== 'undefined' && typeof window.Bugsnag === 'object') {
-    bugsnag = window.Bugsnag
-  } else if (bugsnag) {
+  if (bugsnag) {
     typeof bugsnag.notifyException === 'function' ? bugsnag.notifyException(error) : bugsnag.notify(error)
   } else {
     return warn()


### PR DESCRIPTION
Make this middleware agnostic of the `bugsnag` instance. It can be used both client side ([`bugsnag-js`](http://npmjs.com/package/bugsnag-js)) and server side ([`bugsnag`](http://npmjs.com/package/bugsnag)).

## Usage
### Server side
```js
const { createStore, applyMiddleware } = require('redux')
const busgnag = require('bugsnag')
const bugsnagMiddleware = require('redux-bugsnag')

const middleware = bugsnagMiddleware(bugsnag)
createStore(reducers, applyMiddleware(middleware))
```

### Client side
```js
const { createStore, applyMiddleware } = require('redux')
const busgnag = require('bugsnag-js')
const bugsnagMiddleware = require('redux-bugsnag')

const middleware = bugsnagMiddleware(bugsnag)
createStore(reducers, applyMiddleware(middleware))
```

### Universal
With `webpack` you can use the [`DefinePlugin`](https://webpack.github.io/docs/list-of-plugins.html#defineplugin) to set a special variable that indicates you are in the browser (otherwise you can asume you are in server).

```js
const { createStore, applyMiddleware } = require('redux')
const busgnag = process.env.IS_BROWSER ? require('bugsnag-js') : require('bugsnag')
const bugsnagMiddleware = require('redux-bugsnag')

const middleware = bugsnagMiddleware(bugsnag)
createStore(reducers, applyMiddleware(middleware))
```

Closes #3 